### PR TITLE
Adjust styling to improve display of settings modal

### DIFF
--- a/components/SettingModal.style.tsx
+++ b/components/SettingModal.style.tsx
@@ -18,7 +18,8 @@ export const ModalWrapper = styled.div`
 export const ModalContent = styled.div`
   position: relative;
   width: 40rem;
-  height: 10rem;
+  max-width: 90vw;
+  min-height: 10rem;
   background-color: #fff;
   padding: 20px;
   display: flex;
@@ -59,7 +60,6 @@ export const ColorPickerWrapper = styled.div`
   display: flex;
   justify-content: space-around;
   flex-wrap: wrap;
-  width: 100%;
   padding: 20px;
 
   div {

--- a/components/SettingModal.style.tsx
+++ b/components/SettingModal.style.tsx
@@ -20,6 +20,7 @@ export const ModalContent = styled.div`
   width: 40rem;
   max-width: 90vw;
   min-height: 10rem;
+  max-height: 90vh;
   background-color: #fff;
   padding: 20px;
   display: flex;


### PR DESCRIPTION
Hi, I made some minor modifications to the SettingModal.style.tsx to improve the display of the setting modal on smaller displays. 

The pictures from a small viewport width.

### Before:

![image](https://github.com/riccardobertolini/lofi-music/assets/44126458/aaeb67f9-4919-452b-a62e-dde40dfb49c2)


### After:

![image](https://github.com/riccardobertolini/lofi-music/assets/44126458/6d266d5a-2c39-4571-a65c-15091c17b714)


Now simulated on 320px width phone:

### Before:

![image](https://github.com/riccardobertolini/lofi-music/assets/44126458/e46244be-44a0-4c3a-a8d6-7ed45ce10796)


### After:

![image](https://github.com/riccardobertolini/lofi-music/assets/44126458/5ad544b7-2bd0-41ec-a158-044070754d5c)
