### PR TITLE
Fix shuffling and turning off tracks negative bug (issue #31)

### DIFF
--- a/components/MusicTiles.tsx
+++ b/components/MusicTiles.tsx
@@ -53,7 +53,7 @@ const MusicTiles = ({ musicList, randomTracks }: MusicTilesProp) => {
 
   const stopAll = () => {
     doStopAllTrigger((prevStopAllTrigger) => prevStopAllTrigger + 1)
-    setActiveSounds(0)
+    //setActiveSounds(0)
     setMinutes(0)
     setTimer(0)
   }
@@ -61,6 +61,10 @@ const MusicTiles = ({ musicList, randomTracks }: MusicTilesProp) => {
     setMinutes(minutes + 1)
     setTimer(0)
   }
+  useEffect(() => {
+    setActiveSounds(0)
+  },[])
+
   return (
     <div>
       <ActiveSounds

--- a/components/tilePlayer.tsx
+++ b/components/tilePlayer.tsx
@@ -49,9 +49,13 @@ export const TilePlayer = ({
     isPlaying ? setPlaying(true) : setPlaying(false)
   }, [isPlaying])
 
+  useEffect(() => {
+    incrementActiveSounds(playing)
+  }, [playing])
+
   const togglePlay = () => {
     setPlaying((prevPlaying) => !prevPlaying)
-    incrementActiveSounds(!playing)
+    // incrementActiveSounds(!playing)
   }
 
   const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
As far as I can tell this should fix issue #31, the active sounds count going into negative when disabling tracks that began playing via shuffle.