### PR TITLE
Fix footer link to github not being clickable (issue#84)

### DIFF
--- a/components/ActiveSounds.tsx
+++ b/components/ActiveSounds.tsx
@@ -25,7 +25,7 @@ const ActiveSounds: FC<ActiveSoundsProps> = ({
   stopAll,
   setMasterVolume,
 }) => {
-  let opacityValue = activeSounds ? 1 : 0
+  let displayValue = activeSounds ? 'block' : 'none'
   const { tabIndex } = useAccessibilityContext()
 
   const handleMasterVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -34,7 +34,7 @@ const ActiveSounds: FC<ActiveSoundsProps> = ({
   }
 
   return (
-    <ControlBar style={{ opacity: opacityValue }}>
+    <ControlBar style={{ display: displayValue }}>
       <Row>
         <TimerText>
           {minutes < 10 ? `0${minutes}` : minutes}:


### PR DESCRIPTION
Changed 'opacity 0' to 'display none' when control bar is not active. This should fix issue #84 .