### PR TITLE
Add button media query, center volume

### DIFF
--- a/components/ActiveSounds.style.tsx
+++ b/components/ActiveSounds.style.tsx
@@ -60,6 +60,11 @@ export const StopAllButton = styled.button`
   &:hover {
     background-color: #ff69b4;
   }
+
+  @media (max-width: 650px) {
+    font-size: 16px;
+    padding: 12px 24px;
+  }
 `
 
 export const VolumeIcon = styled.span`


### PR DESCRIPTION
#97 
1. Added media query to devices with max-width 650px to address button styling issues.

![image](https://github.com/riccardobertolini/lofi-music/assets/68170283/7cf4ff68-f414-43cb-95a5-4c8ed090b218)

2. Do I understand correctly that you would like both the volume icon and volume control to be centered at the bottom as one unit? Wanted to confirm with you before addressing.

*Let me know if any additional changes are needed to this PR, I would be happy to address them immediately.