### PR TITLE
add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION

Updates were scheduled to "weekly" to avoid overwhelming changes. The open-pull-requests-limit is set to 0, ensuring that updates won't automatically trigger pull requests. We can adjust these settings as needed.

Let me know if you have any preferences in configuration and I will make changes immediately.

Closes #26 

