### PR TITLE
Added feature - Saving user theme (refers to issue #70)

### DIFF
--- a/components/SettingModal.tsx
+++ b/components/SettingModal.tsx
@@ -82,8 +82,19 @@ const SettingModal = () => {
       setModalVisible(false)
     }
   }
-
+  
   useEffect((): (() => void) => {
+    const savedUserTheme = localStorage.getItem("user-theme");
+
+    if(savedUserTheme) {
+      const parsedUserTheme = JSON.parse(savedUserTheme) as ColorTheme;
+      const matchingTheme = themes.find((theme) => theme.name === parsedUserTheme.name);
+      setSelectedTheme(matchingTheme ?? themes[0]);
+    }
+    else {
+      setSelectedTheme(themes[0])
+    }
+
     document.addEventListener('mousedown', outsideClick)
     return () => {
       document.removeEventListener('mousedown', outsideClick)
@@ -94,8 +105,7 @@ const SettingModal = () => {
     if (selectedTheme) {
       document.documentElement.style.backgroundColor = selectedTheme.fallback
       document.documentElement.style.backgroundImage = selectedTheme.gradient
-    } else {
-      setSelectedTheme(themes[0])
+      localStorage.setItem("user-theme", JSON.stringify(selectedTheme));
     }
   }, [selectedTheme])
 


### PR DESCRIPTION
Referring to the enhancement opportunity for [#70](https://github.com/riccardobertolini/lofi-music/issues/70)

The last selected theme will be saved to the user's localStorage. This saved theme data is fetched when the user revisits the website.

Note: I tried creating a ColorTheme object directly from the stored object, but I was unable to use the fallback() and gradient() methods required for setting a theme just from JSON.parse()-ing. I decided to use the theme name as an identifier to get the theme object directly from the themes[] array. A future update could be to add a unique number identifier for each theme.

https://github.com/user-attachments/assets/4124a5b9-e2cc-4835-a731-1a76922a457a

