### PR TITLE
fix: patch CVE-2025-66478 — upgrade Next.js to ^15.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@emotion/styled": "^11.13.5",
     "@mui/icons-material": "^6.5.0",
     "@mui/material": "^6.5.0",
-    "next": "^15.1.5",
+    "next": "^15.3.1",
     "path": "0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
## Security Fix: CVE-2025-66478 (CVSS 10.0)

### Problem
`next@15.1.5` (resolving to `15.2.4`) ships with a **critical Remote Code Execution vulnerability** in the React Server Components protocol (also tracked as CVE-2025-55182). This is a CVSS 10.0 severity issue that allows attackers to execute arbitrary code on the server.

Reference: https://nextjs.org/blog/CVE-2025-66478

### Change
| Package | Before | After |
|---|---|---|
| `next` | `^15.1.5` | `^15.3.1` |

`react` and `react-dom` are left at `^18.3.1` since the MUI/Emotion stack used in this project is not yet fully compatible with React 19.

### After merging
Run `npm install` locally to regenerate `package-lock.json` with the patched version.